### PR TITLE
Add post-build style injection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,17 @@
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96">
     <link rel="stylesheet" type="text/css" href="css/page.css?v=2025-06-09T00%3A35%3A04.088Z">
-  </head>
+  <!-- hide-unwanted-elements -->
+<style>
+#indicators {
+  display: none;
+}
+
+#canvas-buttons-column {
+  display: none;
+}
+</style>
+</head>
 
   <body>
     <header>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "pre-commit": "npm run rebuild",
     "build-page": "ts-node-script src/generate-page.ts",
     "build": "npm run build-page && npm run webpack",
+    "postbuild": "node scripts/add-style.js",
     "clean": "shx rm -rf docs/* **/*generated.*",
     "rebuild": "npm run clean && npm run build",
     "webpack": "webpack --config src/config/webpack.config.js"

--- a/scripts/add-style.js
+++ b/scripts/add-style.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '..', 'docs', 'index.html');
+let html = fs.readFileSync(filePath, 'utf8');
+const marker = '<!-- hide-unwanted-elements -->';
+const styleSnippet = `${marker}\n<style>\n#indicators {\n  display: none;\n}\n\n#canvas-buttons-column {\n  display: none;\n}\n</style>`;
+
+if (!html.includes(marker)) {
+  html = html.replace('</head>', `${styleSnippet}\n</head>`);
+  fs.writeFileSync(filePath, html, 'utf8');
+  console.log('Added style to hide indicators and canvas buttons.');
+} else {
+  console.log('Hide style already applied.');
+}


### PR DESCRIPTION
## Summary
- add a postbuild script that hides indicators and canvas buttons in `index.html`
- run this script automatically after the build

## Testing
- `npm install`
- `npm run build` *(fails: ENOENT for `template.ejs`)*

------
https://chatgpt.com/codex/tasks/task_b_684630f480a4833385b8fb0699a27988